### PR TITLE
Corrected typo 

### DIFF
--- a/exercises/week_3/bonus/structural_tests.py
+++ b/exercises/week_3/bonus/structural_tests.py
@@ -80,7 +80,7 @@ class Testing(TestCase):
             self.assertGreaterEqual(
                 analyzer.stats["for"],
                 1,
-                "Youd should use a for loop to iterates through the letters of the user input.",
+                "You should use a for loop to iterates through the letters of the user input.",
             )
 
     def test_mod(self):


### PR DESCRIPTION
There was a "Youd" instead of "You" in a structural test. It's hereby gone.